### PR TITLE
Server: remove unused variable

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -1,4 +1,3 @@
-
 /**
  * Module dependencies.
  */
@@ -30,7 +29,6 @@ function Server() {
   this.hostname = os.hostname();
   this.title = process.title;
   this.pid = process.pid;
-  this.active = false;
   this.port = 4322;
   this.regexp = null;
   this.remote = null;


### PR DESCRIPTION
I guess `active` was not in use.
