### PR TITLE
remote: add process.{stdout,stderr}

### DIFF
--- a/lib/local.js
+++ b/lib/local.js
@@ -66,19 +66,34 @@ Local.prototype.onsocket = function(sock){
   actor.send('subscribe', this.opts);
   actor.on('trace', this.trace.bind(this));
   actor.on('event', this.event.bind(this));
-  actor.on('stdio', this.stdio.bind(this));
+  actor.on('stdout', this.stdout.bind(this));
+  actor.on('stderr', this.stderr.bind(this));
 };
 
 /**
- * Handle stdio message.
+ * Handle stdout message.
  *
- * @param {Object} msg
+ * @param {String|Buffer} msg
+ * @param {Function=} reply
  * @api private
  */
 
-Local.prototype.stdio = function(msg){
-  debug('stdio %j', msg);
-  process[msg.stream].write(msg.value);
+Local.prototype.stdout = function(msg, reply){
+  debug('stdout %j', msg);
+  process.stdout.write(msg, reply);
+};
+
+/**
+ * Handle stderr message.
+ *
+ * @param {String|Buffer} msg
+ * @param {Function=} reply
+ * @api private
+ */
+
+Local.prototype.stderr = function(msg, reply){
+  debug('stderr %j', msg);
+  process.stderr.write(msg, reply);
 };
 
 /**

--- a/lib/remote.js
+++ b/lib/remote.js
@@ -61,10 +61,7 @@ Remote.prototype.log = function(){
   var str = util.format.apply(this, arguments) + '\n'
   debug('log %j', str);
   if (!this.actor) return debug('no actor');
-  this.actor.send('stdio', {
-    stream: 'stdout',
-    value: str
-  });
+  this.actor.send('stdout', str);
 };
 
 /**
@@ -82,10 +79,7 @@ Remote.prototype.dir = function(){
   debug('dir %j', str);
   if (!this.actor) return debug('no actor');
   var prefix = [this.server.hostname, this.server.title, this.server.pid].join('/');
-  this.actor.send('stdio', {
-    stream: 'stdout',
-    value: prefix + ' >> ' + str
-  });
+  this.actor.send('stdout', prefix + ' >> ' + str);
 };
 
 /**
@@ -99,10 +93,7 @@ Remote.prototype.error = function(){
   var str = util.format.apply(this, arguments) + '\n'
   debug('error %j', str);
   if (!this.actor) return debug('no actor');
-  this.actor.send('stdio', {
-    stream: 'stderr',
-    value: str
-  });
+  this.actor.send('stderr', str);
 };
 
 /**

--- a/lib/remote.js
+++ b/lib/remote.js
@@ -7,6 +7,7 @@ var debug = require('debug')('jstrace:remote');
 var assert = require('assert');
 var utils = require('./utils');
 var util = require('util');
+var Transform = require('stream').Transform;
 
 /**
  * Expose `Remote`.
@@ -25,7 +26,7 @@ module.exports = Remote;
 
 function Remote(body, server) {
   body = parse(body);
-  this.fn = new Function('traces', 'console', 'require', body);
+  this.fn = new Function('traces', 'console', 'process', 'require', body);
   this.actor = server.actor;
   this.server = server;
   this.patterns = [];
@@ -42,12 +43,59 @@ function Remote(body, server) {
  */
 
 Remote.prototype.invoke = function(){
+  var stdio = {
+    stdout: this.stdout(),
+    stderr: this.stderr()
+  };
+
   try {
-    this.fn(this, this, require);
+    this.fn(this, this, stdio, require);
   } catch (err) {
     // TODO: decorate with hostname/pid etc
     this.error(err.stack);
   }
+};
+
+/**
+ * Remote process.stdout implementation.
+ *
+ * @return {Stream}
+ * @api private
+ */
+
+Remote.prototype.stdout = function(){
+  var self = this;
+  var stream = Transform();
+  stream._transform = function(chunk, _, done){
+    debug('stdout %j', chunk.toString());
+    if (!self.actor) {
+      debug('no actor');
+      return done();
+    }
+    self.actor.send('stdout', chunk, done);
+  };
+  return stream;
+};
+
+/**
+ * Remote process.stderr implementation.
+ *
+ * @return {Stream}
+ * @api private
+ */
+
+Remote.prototype.stderr = function(){
+  var self = this;
+  var stream = Transform();
+  stream._transform = function(chunk, _, done){
+    debug('stderr %j', chunk.toString());
+    if (!self.actor) {
+      debug('no actor');
+      return done();
+    }
+    self.actor.send('stderr', chunk, done);
+  };
+  return stream;
 };
 
 /**


### PR DESCRIPTION
First I refactored the actor protocol to take stdio data as argument and not member of an object (like `{stream:'stdout',val:"foo"}`) so it works with buffers too.

Then i added `process.{stdout,stderr}` as through streams for remote scripts.
- [ ] Should I swap `require('stream').Transform` with `require('readable-stream').Transform`, for `0.8.x` support?
- [ ] <del>Should the remote fn actually override `process.{stdout,stderr}` instead of just using the passed in `process`, so node modules like `clear`, which are not in the same scope, also get to use the patched stdio streams?</del>
