### PR TITLE
fix process title filtering

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -53,7 +53,7 @@ Server.prototype.subscribe = function(opts){
   if (opts.pid && opts.pid != this.pid) return debug('pid mismatch');
 
   // process title filtering
-  if (opts.name && opts.name != this.title) return debug('title mismatch');
+  if (opts.title && opts.title != this.title) return debug('title mismatch');
 
   // patterns
   this.regexp = utils.patterns(opts.patterns);


### PR DESCRIPTION
the bin uses `title` instead of `name`
