### PR TITLE
Fix reserved properties

### DIFF
--- a/lib/local.js
+++ b/lib/local.js
@@ -67,6 +67,7 @@ Local.prototype.onsocket = function(sock){
   actor.on('trace', this.trace.bind(this));
   actor.on('event', this.event.bind(this));
   actor.on('stdio', this.stdio.bind(this));
+  actor.on('error', this.error.bind(this));
 };
 
 /**
@@ -107,6 +108,17 @@ Local.prototype.trace = function(trace){
     if (!h.regexp.test(trace.name)) return;
     h.fn(trace);
   });
+};
+
+/**
+ * Print remote errors.
+ *
+ * @param {String} stack
+ * @api private
+ */
+
+Local.prototype.error = function(stack){
+  console.error(stack);
 };
 
 /**

--- a/lib/remote.js
+++ b/lib/remote.js
@@ -81,10 +81,9 @@ Remote.prototype.dir = function(){
   var str = util.format.apply(this, arguments) + '\n'
   debug('dir %j', str);
   if (!this.actor) return debug('no actor');
-  var prefix = [this.server.hostname, this.server.title, this.server.pid].join('/');
   this.actor.send('stdio', {
     stream: 'stdout',
-    value: prefix + ' >> ' + str
+    value: this.server.prefix(str)
   });
 };
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -189,6 +189,19 @@ Server.prototype.start = function(){
 };
 
 /**
+ * Prefix `str` with info about the server.
+ *
+ * @param {String} str
+ * @return {String}
+ * @api private
+ */
+
+Server.prototype.prefix = function(str){
+  var pre = [this.hostname, this.title, this.pid].join('/');
+  return pre + ' >> ' + str;
+};
+
+/**
  * Merge `b` into `a` and return `a`.
  *
  * Throws if properties overlap.

--- a/lib/server.js
+++ b/lib/server.js
@@ -97,12 +97,13 @@ Server.prototype.subscribed = function(name){
 Server.prototype.send = function(name, obj){
   debug('send %j %j', name, obj);
   if (!this.actor) return debug('no actor');
+
   try {
     obj = this.trace(name, obj);
   } catch (err) {
-    console.error(err);
-    return;
+    return this.actor.send('error', this.prefix(err.stack));
   }
+
   this.actor.send('trace', this.trace(name, obj));
 };
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -104,7 +104,7 @@ Server.prototype.send = function(name, obj){
     return this.actor.send('error', this.prefix(err.stack));
   }
 
-  this.actor.send('trace', this.trace(name, obj));
+  this.actor.send('trace', obj);
 };
 
 /**

--- a/lib/server.js
+++ b/lib/server.js
@@ -97,6 +97,12 @@ Server.prototype.subscribed = function(name){
 Server.prototype.send = function(name, obj){
   debug('send %j %j', name, obj);
   if (!this.actor) return debug('no actor');
+  try {
+    obj = this.trace(name, obj);
+  } catch (err) {
+    console.error(err);
+    return;
+  }
   this.actor.send('trace', this.trace(name, obj));
 };
 
@@ -185,9 +191,12 @@ Server.prototype.start = function(){
 /**
  * Merge `b` into `a` and return `a`.
  *
+ * Throws if properties overlap.
+ *
  * @param {Object} a
  * @param {Object} b
  * @return {Object} a
+ * @throws {Error}
  * @api private
  */
 
@@ -197,6 +206,9 @@ function merge(a, b) {
   if (b.toJSON) b = b.toJSON();
 
   Object.keys(b).forEach(function(k){
+    if ('undefined' != typeof a[k]) {
+      throw new Error('reserved property: ' + k);
+    }
     a[k] = b[k];
   });
 


### PR DESCRIPTION
If you do `trace('foo', { name: 'bar' })` that overrides an internally property, but you're not notified of that.

The first commit implements warning on the server's stderr, if you just want to merge that.

However, the client should ultimately print the error, so the client is the only site jstrace ever prints something on.

`server.error(str)` and `remote.error(str)` could probably be combined somehow...
