### PR TITLE
fix sometimes off server.title

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -27,13 +27,17 @@ function Server() {
   this.connect = this.connect.bind(this);
   this.backoff = new Backoff({ min: 100, max: 5000 });
   this.hostname = os.hostname();
-  this.title = process.title;
   this.pid = process.pid;
   this.port = 4322;
   this.regexp = null;
   this.remote = null;
   this.remoteRegexp = null;
   this.subscribing = false;
+
+  Object.defineProperty(this, 'title', {
+    get: function(){ return process.title },
+    enumerable: true
+  });
 }
 
 /**


### PR DESCRIPTION
although I had `process.title = 'appname'` in my bin script, after all the `require()`s, the server's title was still the old value, therefore process title filtering didn't work
